### PR TITLE
Automatically update formula on new release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ install:
 # command to run tests
 script:
   - git config credential.helper '!f() { sleep 1; echo "username=${GIT_USER}"; echo "password=${GIT_PASSWORD}"; }; f'
+  - git clone https://github.com/justinethier/cyclone.git
+  - git clone https://github.com/justinethier/cyclone-bootstrap.git
   - export PIPENV_IGNORE_VIRTUALENVS=1
   - pipenv install --ignore-pipfile
   - pipenv run ./update-formulas.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: python
 python:
   - "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 install:
   - pip install --upgrade pip
   - pip install pipenv
-  - sudo apt -y install hub
+  - sudo snap install --classic hub
 # command to run tests
 script:
   - git config credential.helper '!f() { sleep 1; echo "username=${GIT_USER}"; echo "password=${GIT_PASSWORD}"; }; f'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 install:
   - pip install --upgrade pip
   - pip install pipenv
-  - pipenv install
+  - pipenv install --ignore-pipfile 
 # command to run tests
 script:
   - pipenv shell

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
   - sudo snap install --classic hub
 # command to run tests
 script:
-  - git config credential.helper '!f() { sleep 1; echo "username=${GIT_USER}"; echo "password=${GIT_PASSWORD}"; }; f'
+  - git config credential.helper '!f() { sleep 1; echo "username=${GITHUB_USER}"; echo "password=${GITHUB_PASSWORD}"; }; f'
   - export PIPENV_IGNORE_VIRTUALENVS=1
   - pipenv install --ignore-pipfile
   - pipenv run ./update-formulas.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
 install:
   - pip install --upgrade pip
   - pip install pipenv
+  - pipenv install
 # command to run tests
 script:
   - pipenv shell

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,5 @@ install:
 # command to run tests
 script:
   - export PIPENV_IGNORE_VIRTUALENVS=1
-  - pipenv --ignore-pipfile install 
+  - pipenv install --ignore-pipfile
   - pipenv run ./update-formulas.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ python:
 install:
   - pip install --upgrade pip
   - pip install pipenv
-  - pipenv install --ignore-pipfile 
 # command to run tests
 script:
+  - export PIPENV_IGNORE_VIRTUALENVS=1
+  - pipenv install --ignore-pipfile 
   - pipenv run ./update-formulas.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ install:
   - pip install pipenv
 # command to run tests
 script:
+  - git config credential.helper '!f() { sleep 1; echo "username=${GIT_USER}"; echo "password=${GIT_PASSWORD}"; }; f'
   - export PIPENV_IGNORE_VIRTUALENVS=1
   - pipenv install --ignore-pipfile
   - pipenv run ./update-formulas.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
 install:
   - pip install --upgrade pip
   - pip install pipenv
+  - sudo apt -y install hub
 # command to run tests
 script:
   - git config credential.helper '!f() { sleep 1; echo "username=${GIT_USER}"; echo "password=${GIT_PASSWORD}"; }; f'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+python:
+  - "3.6"
+# command to install dependencies
+install:
+  - pip install --upgrade pip
+  - pip install pipenv
+# command to run tests
+script:
+  - pipenv shell
+  - ./update-formulas.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ install:
 # command to run tests
 script:
   - git config credential.helper '!f() { sleep 1; echo "username=${GIT_USER}"; echo "password=${GIT_PASSWORD}"; }; f'
-  - git clone https://github.com/justinethier/cyclone.git
-  - git clone https://github.com/justinethier/cyclone-bootstrap.git
   - export PIPENV_IGNORE_VIRTUALENVS=1
   - pipenv install --ignore-pipfile
   - pipenv run ./update-formulas.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,5 @@ install:
 # command to run tests
 script:
   - export PIPENV_IGNORE_VIRTUALENVS=1
-  - pipenv install --ignore-pipfile 
+  - pipenv --ignore-pipfile install 
   - pipenv run ./update-formulas.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,4 @@ install:
   - pipenv install --ignore-pipfile 
 # command to run tests
 script:
-  - pipenv shell
-  - ./update-formulas.py
+  - pipenv run ./update-formulas.py

--- a/Pipfile
+++ b/Pipfile
@@ -11,7 +11,6 @@ ipython = "*"
 gitpython = "*"
 requests = "*"
 git-pull-request = "*"
-git-spindle = "*"
 
 [requires]
 python_version = "3.6"

--- a/Pipfile
+++ b/Pipfile
@@ -11,6 +11,7 @@ ipython = "*"
 gitpython = "*"
 requests = "*"
 git-pull-request = "*"
+git-spindle = "*"
 
 [requires]
 python_version = "3.6"

--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ sh = "*"
 ipython = "*"
 gitpython = "*"
 requests = "*"
+git-pull-request = "*"
 
 [requires]
 python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "99e8bf22ac4d17a3e08f13226f558de9a61440dce111687c2946d538cb9b9012"
+            "sha256": "d856a121ac31003646b312fa9a41ca1d2242704fbcac12df9dfc3106d5242a60"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -66,12 +66,6 @@
             ],
             "version": "==1.2.5"
         },
-        "docopt": {
-            "hashes": [
-                "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"
-            ],
-            "version": "==0.6.2"
-        },
         "git-pull-request": {
             "hashes": [
                 "sha256:ad4618972946f4b53a4494eb88c9031b64963987741a3ebdfdb0141391dac961",
@@ -80,26 +74,12 @@
             "index": "pypi",
             "version": "==2.10.0"
         },
-        "git-spindle": {
-            "hashes": [
-                "sha256:566efcc2a61582340aa1cb25616fa34147c2e38def508d0ab1860373072b54d0"
-            ],
-            "index": "pypi",
-            "version": "==3.4.4"
-        },
         "gitdb2": {
             "hashes": [
                 "sha256:83361131a1836661a155172932a13c08bda2db3674e4caa32368aa6eb02f38c2",
                 "sha256:e3a0141c5f2a3f635c7209d56c496ebe1ad35da82fe4d3ec4aaa36278d70648a"
             ],
             "version": "==2.0.5"
-        },
-        "github3.py": {
-            "hashes": [
-                "sha256:650d31dbc3f3290ea56b18cfd0e72e00bbbd6777436578865a7e45b496f09e4c",
-                "sha256:b831db85d7ff4a99d6f4e8368918095afeea10f0ec50798f9a937c830ab41dc5"
-            ],
-            "version": "==0.9.6"
         },
         "gitpython": {
             "hashes": [
@@ -232,21 +212,6 @@
             ],
             "version": "==4.3.2"
         },
-        "uritemplate": {
-            "hashes": [
-                "sha256:01c69f4fe8ed503b2951bef85d996a9d22434d2431584b5b107b2981ff416fbd",
-                "sha256:1b9c467a940ce9fb9f50df819e8ddd14696f89b9a8cc87ac77952ba416e0a8fd",
-                "sha256:c02643cebe23fc8adb5e6becffe201185bf06c40bda5c0b4028a93f1527d011d"
-            ],
-            "version": "==3.0.0"
-        },
-        "uritemplate.py": {
-            "hashes": [
-                "sha256:a0c459569e80678c473175666e0d1b3af5bc9a13f84463ec74f808f3dd12ca47",
-                "sha256:e0cdeb0f55ec18e1580974e8017cd188549aacc2aba664ae756adb390b9d45b4"
-            ],
-            "version": "==3.0.2"
-        },
         "urllib3": {
             "hashes": [
                 "sha256:4c291ca23bbb55c76518905869ef34bdd5f0e46af7afe6861e8375643ffee1a0",
@@ -260,12 +225,6 @@
                 "sha256:f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c"
             ],
             "version": "==0.1.7"
-        },
-        "whelk": {
-            "hashes": [
-                "sha256:d109d270a72678949bfb51f384bb32a601875fe4fe016ebb48e9d7f6dd7564bc"
-            ],
-            "version": "==2.7.1"
         },
         "wrapt": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d510f4334b0247c768d5c823dc18e03f1cfe86a81aa27c2295e7385e1db6ed4b"
+            "sha256": "d856a121ac31003646b312fa9a41ca1d2242704fbcac12df9dfc3106d5242a60"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -45,12 +45,34 @@
             ],
             "version": "==3.0.4"
         },
+        "daiquiri": {
+            "hashes": [
+                "sha256:8832f28e110165b905993b4bdab638a3c245f5671d5976f226f2628e7d2e7862",
+                "sha256:ac0e69ac0a8c4ceabcf57f14ba4dc7b5940dc2bf9d1ee620d2ae9fa8f78c7891"
+            ],
+            "version": "==1.5.0"
+        },
         "decorator": {
             "hashes": [
                 "sha256:86156361c50488b84a3f148056ea716ca587df2f0de1d34750d35c21312725de",
                 "sha256:f069f3a01830ca754ba5258fde2278454a0b5b79e0d7f5c13b3b97e57d4acff6"
             ],
             "version": "==4.4.0"
+        },
+        "deprecated": {
+            "hashes": [
+                "sha256:2f293eb0eee34b1fcf3da530fe8fc4b0d71d43ddc2dc78e2ffb444b6c0868557",
+                "sha256:749f6cdcfbdc3f79258f8154bad43fced95adc632c337675d0385959895894bc"
+            ],
+            "version": "==1.2.5"
+        },
+        "git-pull-request": {
+            "hashes": [
+                "sha256:ad4618972946f4b53a4494eb88c9031b64963987741a3ebdfdb0141391dac961",
+                "sha256:bc58561f37db595e9de59392ca2584e74463677e734fd73fe67db7963f40d547"
+            ],
+            "index": "pypi",
+            "version": "==2.10.0"
         },
         "gitdb2": {
             "hashes": [
@@ -133,12 +155,25 @@
             ],
             "version": "==0.6.0"
         },
+        "pygithub": {
+            "hashes": [
+                "sha256:2ce91d4990efbfb7a0a1abd06e2106a3998a4a5810a4bdd3c1b6be5499918e9b"
+            ],
+            "version": "==1.43.7"
+        },
         "pygments": {
             "hashes": [
                 "sha256:5ffada19f6203563680669ee7f53b64dabbeb100eb51b61996085e99c03b284a",
                 "sha256:e8218dd399a61674745138520d0d4cf2621d7e032439341bc3f647bff125818d"
             ],
             "version": "==2.3.1"
+        },
+        "pyjwt": {
+            "hashes": [
+                "sha256:5c6eca3c2940464d106b99ba83b00c6add741c9becaec087fb7ccdefea71350e",
+                "sha256:8d59a976fb773f3e6a39c85636357c4f0e242707394cadadd9814f5cbaa20e96"
+            ],
+            "version": "==1.7.1"
         },
         "requests": {
             "hashes": [
@@ -190,6 +225,13 @@
                 "sha256:f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c"
             ],
             "version": "==0.1.7"
+        },
+        "wrapt": {
+            "hashes": [
+                "sha256:373f08ea577060a4dd44660907f32865371a57f054ab458dbdb461f4400449df",
+                "sha256:4aea003270831cceb8a90ff27c4031da6ead7ec1886023b80ce0dfe0adf61533"
+            ],
+            "version": "==1.11.1"
         }
     },
     "develop": {}

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -179,10 +179,10 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
-                "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
+                "sha256:4c291ca23bbb55c76518905869ef34bdd5f0e46af7afe6861e8375643ffee1a0",
+                "sha256:9a247273df709c4fedb38c711e44292304f73f39ab01beda9f6b9fc375669ac3"
             ],
-            "version": "==1.24.1"
+            "version": "==1.24.2"
         },
         "wcwidth": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d856a121ac31003646b312fa9a41ca1d2242704fbcac12df9dfc3106d5242a60"
+            "sha256": "99e8bf22ac4d17a3e08f13226f558de9a61440dce111687c2946d538cb9b9012"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -66,6 +66,12 @@
             ],
             "version": "==1.2.5"
         },
+        "docopt": {
+            "hashes": [
+                "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"
+            ],
+            "version": "==0.6.2"
+        },
         "git-pull-request": {
             "hashes": [
                 "sha256:ad4618972946f4b53a4494eb88c9031b64963987741a3ebdfdb0141391dac961",
@@ -74,12 +80,26 @@
             "index": "pypi",
             "version": "==2.10.0"
         },
+        "git-spindle": {
+            "hashes": [
+                "sha256:566efcc2a61582340aa1cb25616fa34147c2e38def508d0ab1860373072b54d0"
+            ],
+            "index": "pypi",
+            "version": "==3.4.4"
+        },
         "gitdb2": {
             "hashes": [
                 "sha256:83361131a1836661a155172932a13c08bda2db3674e4caa32368aa6eb02f38c2",
                 "sha256:e3a0141c5f2a3f635c7209d56c496ebe1ad35da82fe4d3ec4aaa36278d70648a"
             ],
             "version": "==2.0.5"
+        },
+        "github3.py": {
+            "hashes": [
+                "sha256:650d31dbc3f3290ea56b18cfd0e72e00bbbd6777436578865a7e45b496f09e4c",
+                "sha256:b831db85d7ff4a99d6f4e8368918095afeea10f0ec50798f9a937c830ab41dc5"
+            ],
+            "version": "==0.9.6"
         },
         "gitpython": {
             "hashes": [
@@ -212,6 +232,21 @@
             ],
             "version": "==4.3.2"
         },
+        "uritemplate": {
+            "hashes": [
+                "sha256:01c69f4fe8ed503b2951bef85d996a9d22434d2431584b5b107b2981ff416fbd",
+                "sha256:1b9c467a940ce9fb9f50df819e8ddd14696f89b9a8cc87ac77952ba416e0a8fd",
+                "sha256:c02643cebe23fc8adb5e6becffe201185bf06c40bda5c0b4028a93f1527d011d"
+            ],
+            "version": "==3.0.0"
+        },
+        "uritemplate.py": {
+            "hashes": [
+                "sha256:a0c459569e80678c473175666e0d1b3af5bc9a13f84463ec74f808f3dd12ca47",
+                "sha256:e0cdeb0f55ec18e1580974e8017cd188549aacc2aba664ae756adb390b9d45b4"
+            ],
+            "version": "==3.0.2"
+        },
         "urllib3": {
             "hashes": [
                 "sha256:4c291ca23bbb55c76518905869ef34bdd5f0e46af7afe6861e8375643ffee1a0",
@@ -226,9 +261,14 @@
             ],
             "version": "==0.1.7"
         },
+        "whelk": {
+            "hashes": [
+                "sha256:d109d270a72678949bfb51f384bb32a601875fe4fe016ebb48e9d7f6dd7564bc"
+            ],
+            "version": "==2.7.1"
+        },
         "wrapt": {
             "hashes": [
-                "sha256:373f08ea577060a4dd44660907f32865371a57f054ab458dbdb461f4400449df",
                 "sha256:4aea003270831cceb8a90ff27c4031da6ead7ec1886023b80ce0dfe0adf61533"
             ],
             "version": "==1.11.1"

--- a/cyclone-bootstrap.rb
+++ b/cyclone-bootstrap.rb
@@ -3,7 +3,7 @@ class CycloneBootstrap < Formula
   homepage "http://justinethier.github.io/cyclone/"
   url "https://github.com/justinethier/cyclone-bootstrap/archive/v0.11.tar.gz"
   sha256 "acc77b2db98074a41621f8c85b79361d7f3c94fc4af0aae061a1f64e5070b3f9"
-  version "v0.11"
+  version "v0.10"
   depends_on "git"
   depends_on "gcc"
   depends_on "libtommath"

--- a/cyclone-bootstrap.rb
+++ b/cyclone-bootstrap.rb
@@ -1,8 +1,8 @@
 class CycloneBootstrap < Formula
   desc ":cyclone-bootstrap: R7RS Scheme compiler used to bootstrap the cyclone R7RS Scheme compiler"
   homepage "http://justinethier.github.io/cyclone/"
-  url "https://github.com/justinethier/cyclone-bootstrap/archive/v0.11.tar.gz"
-  sha256 "acc77b2db98074a41621f8c85b79361d7f3c94fc4af0aae061a1f64e5070b3f9"
+  url "https://github.com/justinethier/cyclone-bootstrap/archive/v0.10.tar.gz"
+  sha256 "cbdb8b01fe9805c75f8bd6b97f841f78b5bca9cca65898cac5a4242b05ee9037"
   version "v0.10"
   depends_on "git"
   depends_on "gcc"

--- a/cyclone-formula.rb.template
+++ b/cyclone-formula.rb.template
@@ -1,0 +1,66 @@
+class @@CLASSNAME@@ < Formula
+  desc "@@DESCRIPTION@@"
+  homepage "http://justinethier.github.io/cyclone/"
+  url "@@ARCHIVE_URL@@"
+  sha256 "@@ARCHIVE_SHA@@"
+  version "@@ARCHIVE_VERSION@@"
+  depends_on "git"
+  depends_on "gcc"
+  depends_on "libtommath"
+  depends_on "ck"
+  depends_on "cyclone-bootstrap"
+  depends_on :xcode 
+
+  def install_cyclone_files
+    bin.mkdir
+    include.mkdir
+    lib.mkdir
+    share.mkdir
+    libexec.install %w[scheme srfi include]
+    mkdir libexec/"bin"
+    (libexec/"bin").install "cyclone"
+    (libexec/"bin").install "icyc"
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+    mkdir libexec/"lib"
+    (libexec/"lib").install "libcyclone.a"
+    lib.install_symlink Dir["#{libexec}/lib/*"]
+    mkdir include/"cyclone"
+    (include/"cyclone").install_symlink Dir["#{libexec}/include/cyclone/*.h"]
+    mkdir share/"cyclone"
+    mkdir share/"cyclone/scheme"
+    mkdir share/"cyclone/scheme/cyclone"
+    (share/"cyclone/scheme").install_symlink Dir["#{libexec}/scheme/*.sld"]
+    (share/"cyclone/scheme").install_symlink Dir["#{libexec}/scheme/*.o"]
+	(share/"cyclone/scheme").install_symlink Dir["#{libexec}/scheme/*.so"]
+    (share/"cyclone/scheme").install_symlink Dir["#{libexec}/scheme/cyclone/*.sld"]
+    (share/"cyclone/scheme").install_symlink Dir["#{libexec}/scheme/cyclone/*.scm"]
+    (share/"cyclone/scheme").install_symlink Dir["#{libexec}/scheme/cyclone/test.meta"]
+    (share/"cyclone/scheme").install_symlink Dir["#{libexec}/scheme/cyclone/match.meta"]
+    (share/"cyclone/scheme").install_symlink Dir["#{libexec}/scheme/cyclone/array-list.meta"]
+    (share/"cyclone/scheme/cyclone").install_symlink Dir["#{libexec}/scheme/cyclone/*.o"]
+    (share/"cyclone/scheme/cyclone").install_symlink Dir["#{libexec}/scheme/cyclone/*.so"]
+    mkdir share/"cyclone/srfi"
+    (share/"cyclone/srfi").install_symlink Dir["#{libexec}/srfi/*.sld"]
+    (share/"cyclone/srfi").install_symlink Dir["#{libexec}/srfi/*.scm"]
+    mkdir share/"cyclone/srfi/list-queues"
+    (share/"cyclone/srfi/list-queues").install_symlink Dir["#{libexec}/srfi/list-queues/*.scm"]
+    mkdir share/"cyclone/srfi/sorting"
+    (share/"cyclone/srfi/sorting").install_symlink Dir["#{libexec}/srfi/sorting/*.scm"]
+    mkdir share/"cyclone/srfi/sets"
+    (share/"cyclone/srfi/sets").install_symlink Dir["#{libexec}/srfi/sets/*.scm"]
+    (share/"cyclone/srfi").install_symlink Dir["#{libexec}/srfi/*.meta"]
+    (share/"cyclone/srfi").install_symlink Dir["#{libexec}/srfi/*.o"]
+    (share/"cyclone/srfi").install_symlink Dir["#{libexec}/srfi/*.so"]
+  end     
+
+  def install
+    ENV.deparallelize
+    ENV.prepend_path "PATH", "/usr/local/bin"
+    system "make"
+    install_cyclone_files
+  end
+
+  test do
+      system "make test"
+  end
+end

--- a/cyclone.rb
+++ b/cyclone.rb
@@ -3,7 +3,7 @@ class Cyclone < Formula
   homepage "http://justinethier.github.io/cyclone/"
   url "https://github.com/justinethier/cyclone/archive/v0.11.tar.gz"
   sha256 "75536b72f49ad7cb7b8745dd61726af6c8a4a1436675f750b24338e94a1621bb"
-  version "v0.11"
+  version "v0.10"
   depends_on "git"
   depends_on "gcc"
   depends_on "libtommath"

--- a/cyclone.rb
+++ b/cyclone.rb
@@ -1,8 +1,8 @@
 class Cyclone < Formula
   desc ":cyclone: A brand-new compiler that allows practical application development using R7RS Scheme."
   homepage "http://justinethier.github.io/cyclone/"
-  url "https://github.com/justinethier/cyclone/archive/v0.11.tar.gz"
-  sha256 "75536b72f49ad7cb7b8745dd61726af6c8a4a1436675f750b24338e94a1621bb"
+  url "https://github.com/justinethier/cyclone/archive/v0.10.tar.gz"
+  sha256 "c96155cb08c9d97cb6d4e65055ebbf74e8f5e0b05eb336c727ca96705488aba8"
   version "v0.10"
   depends_on "git"
   depends_on "gcc"

--- a/update-formulas.py
+++ b/update-formulas.py
@@ -142,9 +142,8 @@ def get_templates():
         title = "update homebrew formulas to version {}".format(version) 
         message = f"{title}\n\n{title}\nThis pull request was created automatically by a script." 
         sh.git("commit", "-m", title) 
-        sh.env()
         sh.git("push", "--set-upstream", "origin", branch_name)  
-        sh.hub("pull-request", "-m", message)
+        #sh.hub("pull-request", "-m", message)
         print(f"Created pull request for branch {branch_name}.")
     else:
         print("No formulas need updating.")

--- a/update-formulas.py
+++ b/update-formulas.py
@@ -143,7 +143,7 @@ def get_templates():
         message = f"{title}\n\n{title}\nThis pull request was created automatically by a script." 
         sh.git("commit", "-m", title) 
         sh.git("push", "--set-upstream", "origin", branch_name)  
-        #sh.hub("pull-request", "-m", message)
+        sh.hub("pull-request", "-m", message)
         print(f"Created pull request for branch {branch_name}.")
     else:
         print("No formulas need updating.")

--- a/update-formulas.py
+++ b/update-formulas.py
@@ -14,7 +14,7 @@ import sh
 from git import Repo
 from git_pull_request import git_pull_request
 
-HOMEBREW_CYCLONE_PROJECT_URL = "https://github.com/adamfeuer/homebrew-cyclone"
+HOMEBREW_CYCLONE_PROJECT_URL = "git@github.com:adamfeuer/homebrew-cyclone.git"
 
 CYCLONE = "cyclone"
 CYCLONE_PROJECT_URL = f"https://github.com/justinethier/{CYCLONE}"
@@ -129,7 +129,7 @@ def get_templates():
                 with open(formula_file_name, "w") as formula_file:
                     formula_file.write(new_contents)
     if updated:
-        branch_name = "update_formulas_to_version_{}".format(version)
+        branch_name = "update_formulas_to_version_{}".format(version).replace('.', '_')
         sh.git("checkout", "-b", branch_name)
         for formula_file_name in updated:
             sh.git("add", formula_file_name)
@@ -137,15 +137,16 @@ def get_templates():
         message = f"{title}\nThis pull request was created automatically by a script." 
         comment = title
         sh.git("commit", "-m", comment) 
-#        result = git_pull_request(
-#                target_remote=HOMEBREW_CYCLONE_PROJECT_URL,
-#            target_branch=target_branch,
-#            title=title,
-#            message=message,
-#            comment=comment,
-#            rebase=False,
-#            dont_fork=True,
-#        )
+        sh.git("push", "--set-upstream", "origin", branch_name)  
+        result = git_pull_request(
+            #target_remote=HOMEBREW_CYCLONE_PROJECT_URL,
+            target_branch=branch_name,
+            title=title,
+            message=message,
+            comment=comment,
+            rebase=False,
+            dont_fork=True,
+        )
 
 
 def main():

--- a/update-formulas.py
+++ b/update-formulas.py
@@ -59,7 +59,6 @@ ARCHIVE_VERSION = "@@ARCHIVE_VERSION@@"
 BUF_SIZE = 65536  
 
 
-
 def get_sha256(fileobj):
     sha256_hash = hashlib.sha256()
     for byte_block in iter(lambda: fileobj.read(4096),b""):
@@ -106,36 +105,12 @@ def should_update(formula_file_name, archive_version):
     return archive_version != formula_version 
 
 
-def get_templates():
-    with open("cyclone-formula.rb.template") as template:
-        contents = template.read()
-    updated = []
-    version = "NO_VERSION"
-    for project in projects:
-        if os.path.exists(project["name"]):
-            shutil.rmtree(project["name"])
-        sh.git("clone", project["git_repo_url"])
-        formula_file_name = project["formula_file_name"]
-        archive_version = get_most_recent_tag(project["name"])
-        version = archive_version
-        print(f'The latest tag in repo {project["name"]} is {archive_version}.') 
-        shutil.rmtree(project["name"])
-        sh.git("clone", project["git_repo_url"])
-        if should_update(formula_file_name, archive_version):
-            updated.append(formula_file_name)
-            print(f"Updating formula {formula_file_name} to {archive_version}.")
-            if should_update(formula_file_name, archive_version):
-                archive_url = "{}/{}.tar.gz".format(project["releases_url"], archive_version)
-                archive_sha = get_sha256_for_url(archive_url)
-                new_contents = contents.replace(CLASSNAME, project["classname"])
-                new_contents = new_contents.replace(DESCRIPTION, project["description"])
-                new_contents = new_contents.replace(ARCHIVE_URL, archive_url)
-                new_contents = new_contents.replace(ARCHIVE_SHA, archive_sha)
-                new_contents = new_contents.replace(ARCHIVE_VERSION, archive_version)
-                with open(formula_file_name, "w") as formula_file:
-                    formula_file.write(new_contents)
-    if updated:
-        branch_name = "update_formulas_to_version_{}".format(version).replace('.', '_')
+def create_pull_request_if_necessary(updated, version):
+    branch_name = f"update_formulas_to_version_{version.replace('.', '_')}"
+    output = sh.git('ls-remote', 'origin', branch_name)
+    if output.strip():
+        print(f"Branch {branch_name} already exists on server, not creating it or the pull request.")
+    else:
         sh.git("checkout", "-b", branch_name)
         for formula_file_name in updated:
             sh.git("add", formula_file_name)
@@ -145,13 +120,47 @@ def get_templates():
         sh.git("push", "--set-upstream", "origin", branch_name)  
         sh.hub("pull-request", "-m", message)
         print(f"Created pull request for branch {branch_name}.")
-    else:
-        print("No formulas need updating.")
 
+
+def update_formula_for_project(project, template):
+    updated_project = []
+    if os.path.exists(project["name"]):
+        shutil.rmtree(project["name"])
+    sh.git("clone", project["git_repo_url"])
+    formula_file_name = project["formula_file_name"]
+    archive_version = get_most_recent_tag(project["name"])
+    version = archive_version
+    print(f'The latest tag in repo {project["name"]} is {archive_version}.') 
+    shutil.rmtree(project["name"])
+    sh.git("clone", project["git_repo_url"])
+    if should_update(formula_file_name, archive_version):
+        updated_project.append(formula_file_name)
+        print(f"Updating formula {formula_file_name} to {archive_version}.")
+        if should_update(formula_file_name, archive_version):
+            archive_url = "{}/{}.tar.gz".format(project["releases_url"], archive_version)
+            archive_sha = get_sha256_for_url(archive_url)
+            new_contents = template.replace(CLASSNAME, project["classname"])
+            new_contents = new_contents.replace(DESCRIPTION, project["description"])
+            new_contents = new_contents.replace(ARCHIVE_URL, archive_url)
+            new_contents = new_contents.replace(ARCHIVE_SHA, archive_sha)
+            new_contents = new_contents.replace(ARCHIVE_VERSION, archive_version)
+            with open(formula_file_name, "w") as formula_file:
+                formula_file.write(new_contents)
+    return version, updated_project 
 
 
 def main():
-    get_templates()
+    with open("cyclone-formula.rb.template") as template:
+        template_contents = template.read()
+    updated_projects = []
+    version = "NO_VERSION"
+    for project in projects:
+        version, updated_project = update_formula_for_project(project, template_contents)
+        updated_projects += updated_project
+    if updated_projects:
+        create_pull_request_if_necessary(updated_projects, version)
+    else:
+        print("No formulas need updating.")
 
 
 if __name__ == "__main__":

--- a/update-formulas.py
+++ b/update-formulas.py
@@ -134,19 +134,10 @@ def get_templates():
         for formula_file_name in updated:
             sh.git("add", formula_file_name)
         title = "update homebrew formulas to version {}".format(version) 
-        message = f"{title}\nThis pull request was created automatically by a script." 
-        comment = title
-        sh.git("commit", "-m", comment) 
+        message = f"{title}\n\n{title}\nThis pull request was created automatically by a script." 
+        sh.git("commit", "-m", title) 
         sh.git("push", "--set-upstream", "origin", branch_name)  
-        result = git_pull_request(
-            #target_remote=HOMEBREW_CYCLONE_PROJECT_URL,
-            target_branch=branch_name,
-            title=title,
-            message=message,
-            comment=comment,
-            rebase=False,
-            dont_fork=True,
-        )
+        sh.git("hub", "pull-request", "-m", message)
 
 
 def main():

--- a/update-formulas.py
+++ b/update-formulas.py
@@ -142,6 +142,7 @@ def get_templates():
         title = "update homebrew formulas to version {}".format(version) 
         message = f"{title}\n\n{title}\nThis pull request was created automatically by a script." 
         sh.git("commit", "-m", title) 
+        sh.env()
         sh.git("push", "--set-upstream", "origin", branch_name)  
         sh.hub("pull-request", "-m", message)
         print(f"Created pull request for branch {branch_name}.")

--- a/update-formulas.py
+++ b/update-formulas.py
@@ -137,7 +137,7 @@ def get_templates():
         message = f"{title}\n\n{title}\nThis pull request was created automatically by a script." 
         sh.git("commit", "-m", title) 
         sh.git("push", "--set-upstream", "origin", branch_name)  
-        sh.git("hub", "pull-request", "-m", message)
+        sh.hub("pull-request", "-m", message)
 
 
 def main():

--- a/update-formulas.py
+++ b/update-formulas.py
@@ -16,7 +16,7 @@ import sh
 from git import Repo
 from git_pull_request import git_pull_request
 
-HOMEBREW_CYCLONE_PROJECT_URL = "git@github.com:adamfeuer/homebrew-cyclone.git"
+HOMEBREW_CYCLONE_PROJECT_URL = "git@github.com:cyclone-scheme/homebrew-cyclone.git"
 
 CYCLONE = "cyclone"
 CYCLONE_PROJECT_URL = f"https://github.com/justinethier/{CYCLONE}"

--- a/update-formulas.py
+++ b/update-formulas.py
@@ -113,11 +113,12 @@ def get_templates():
         formula_file_name = project["formula_file_name"]
         archive_version = get_most_recent_tag(project["name"])
         version = archive_version
+        print(f'The latest tag in repo {project["name"]} is {archive_version}.') 
         shutil.rmtree(project["name"])
         sh.git("clone", project["git_repo_url"])
         if should_update(formula_file_name, archive_version):
             updated.append(formula_file_name)
-            print("updating formula {}".format(project["name"]))
+            print(f"Updating formula {formula_file_name} to {archive_version}.")
             if should_update(formula_file_name, archive_version):
                 archive_url = "{}/{}.tar.gz".format(project["releases_url"], archive_version)
                 archive_sha = get_sha256_for_url(archive_url)
@@ -138,6 +139,10 @@ def get_templates():
         sh.git("commit", "-m", title) 
         sh.git("push", "--set-upstream", "origin", branch_name)  
         sh.hub("pull-request", "-m", message)
+        print(f"Created pull request for branch {branch_name}.")
+    else:
+        print("No formulas need updating.")
+
 
 
 def main():

--- a/update-formulas.py
+++ b/update-formulas.py
@@ -2,12 +2,14 @@
 
 import sys
 import os
+import shutil
 import time
 import sys
 import hashlib
 import tempfile
 import shutil
 from io import StringIO
+from pathlib import Path
 
 import requests
 import sh
@@ -110,6 +112,9 @@ def get_templates():
     updated = []
     version = "NO_VERSION"
     for project in projects:
+        if os.path.exists(project["name"]):
+            shutil.rmtree(project["name"])
+        sh.git("clone", project["git_repo_url"])
         formula_file_name = project["formula_file_name"]
         archive_version = get_most_recent_tag(project["name"])
         version = archive_version


### PR DESCRIPTION
### Summary

* adds `.travis.yml` and a script that makes it possible to automatically submit a PR to update the homebrew formulas when the `cyclone-scheme` version changes. This should make it easier to keep the Mac homebrew formulas up-to-date with the current released version
* Also updated urllib3 to 1.24.2 to fix CVE-2019-11236

### Impact

* None unless travisci is set up to run periodically.
* Script only submits the PR, and does not commit it automatically.

### Limitations / TODO

* scripts should be implemented in scheme rather than python, but more work is needed before that can happen.

### Testing

* manual 

### travisci.org setup

1. A [developer token](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line) is necessary from github
2. Two environment variables need to be set up in travisci:
  * `GITHUB_USER`: should be the user the script will submit the PR as. Needs commit rights to the `homebrew-cyclone` repo. Ideally should be an account that is not used by a human, in order to differentiate it from human contributions
  * `GITHUB_PASSWORD`: This is the github developer token created in step 1.
3. Set the travisci job to run periodically by configuring a [cron job](https://docs.travis-ci.com/user/cron-jobs/).